### PR TITLE
Cleanup path

### DIFF
--- a/lib/cc/engine/clog/issue/base.rb
+++ b/lib/cc/engine/clog/issue/base.rb
@@ -10,7 +10,7 @@ module CC
               type: 'issue',
               categories: ['Complexity'],
               location: {
-                path: @path,
+                path: path,
                 lines: {
                   begin: 1,
                   end: 1
@@ -19,6 +19,12 @@ module CC
             }
 
             JSON.generate(defaults.merge(options))
+          end
+
+          private
+
+          def path
+            @path.gsub(%r{^\./}, '')
           end
         end
       end

--- a/lib/cc/engine/clog/issue/cyclomatic_complexity.rb
+++ b/lib/cc/engine/clog/issue/cyclomatic_complexity.rb
@@ -22,7 +22,7 @@ module CC
               content: { body: content },
               remediation_points: remediation_points,
               location: {
-                path: @path,
+                path: path,
                 lines: {
                   begin: @from,
                   end: @to

--- a/lib/cc/engine/clog/issue/file_length.rb
+++ b/lib/cc/engine/clog/issue/file_length.rb
@@ -20,7 +20,7 @@ module CC
               content: { body: content },
               remediation_points: remediation_points,
               location: {
-                path: @path,
+                path: path,
                 lines: {
                   begin: 1,
                   end: 1

--- a/lib/cc/engine/clog/issue/function_length.rb
+++ b/lib/cc/engine/clog/issue/function_length.rb
@@ -22,7 +22,7 @@ module CC
               content: { body: content },
               remediation_points: remediation_points,
               location: {
-                path: @path,
+                path: path,
                 lines: {
                   begin: @from,
                   end: @to

--- a/lib/cc/engine/clog/issue/token_complexity.rb
+++ b/lib/cc/engine/clog/issue/token_complexity.rb
@@ -20,7 +20,7 @@ module CC
               content: { body: content },
               remediation_points: remediation_points,
               location: {
-                path: @path,
+                path: path,
                 lines: {
                   begin: 1,
                   end: 1


### PR DESCRIPTION
> can you change the code here https://github.com/masone/codeclimate-clog/blob/master/lib/cc/engine/clog/output_interpreter.rb#L11 to remove the trailing "./" from paths? It messes stuff up a bit in the UI. 
