### PR TITLE
Add language to engine.json

### DIFF
--- a/engine.json
+++ b/engine.json
@@ -5,6 +5,7 @@
     "name": "Christian Felder",
     "email": "ema@rh-productions.ch"
   },
+  "languages": ["CoffeeScript"],
   "version": "0.0.1",
   "spec_version": "0.1"
 }


### PR DESCRIPTION
Working through spec compliance stuff locally, realized this field was missing.
